### PR TITLE
Integrate Account API

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -54,7 +54,6 @@ export function createMainAPI(token) {
     const body = {
       email,
       password,
-      role: 2,
     };
 
     return hit(END_POINTS.TOKEN, METHODS.POST, body);

--- a/api/index.js
+++ b/api/index.js
@@ -5,6 +5,7 @@ const API_KEY = process.env.NEXT_PUBLIC_API_KEY;
 
 const END_POINTS = {
   TOKEN: "/auth/token/",
+  ACCOUNT: "/auth/account/",
   PATIENTS: "/patients/",
 };
 
@@ -63,6 +64,10 @@ export function createMainAPI(token) {
     return hit(END_POINTS.TOKEN, METHODS.DELETE);
   }
 
+  async function getAccount() {
+    return hit(END_POINTS.ACCOUNT, METHODS.GET);
+  }
+
   async function getPatients(parameters) {
     return hit(END_POINTS.PATIENTS + createParameter(parameters), METHODS.GET);
   }
@@ -70,6 +75,7 @@ export function createMainAPI(token) {
   return {
     login,
     logout,
+    getAccount,
     getPatients,
   };
 }

--- a/helpers/utilities.js
+++ b/helpers/utilities.js
@@ -35,3 +35,9 @@ export function createParameter(parts) {
 export function isNone(object) {
   return object === undefined || object === null;
 }
+
+export function isObject(object) {
+  return (
+    typeof object === "object" && !Array.isArray(object) && object !== null
+  );
+}

--- a/pages/_app/index.js
+++ b/pages/_app/index.js
@@ -1,10 +1,10 @@
-import { useState, useReducer, useEffect } from "react";
+import { useState, useReducer, useEffect, useMemo } from "react";
 import { useRouter } from "next/router";
 
 import { Sky } from "@components/index";
 import { AppContext } from "@contexts/index";
 import { createMainAPI } from "@api/index";
-import { isNone } from "@helpers/utilities";
+import { isNone, isObject } from "@helpers/utilities";
 
 import Modal from "./components/Modal";
 import { modalUpdateHandler } from "./functions";
@@ -14,6 +14,7 @@ import "./index.css";
 export default function SpecializedApp({ Component, pageProps }) {
   const [modalDataList, modalDispatch] = useReducer(modalUpdateHandler, []);
   const [user, setUser] = useState(null);
+  const [account, setAccount] = useState(null);
   const router = useRouter();
 
   const modal = {
@@ -33,13 +34,18 @@ export default function SpecializedApp({ Component, pageProps }) {
     isEmpty: modalDataList.length === 0,
   };
 
+  const mainAPI = useMemo(() => createMainAPI(user?.token), [user?.token]);
+
   const appContextValue = {
     modal,
     apis: {
-      main: createMainAPI(user?.token),
+      main: mainAPI,
     },
     isAuthenticated: !isNone(user?.token),
-    user,
+    user: {
+      ...(isObject(user) ? user : {}),
+      ...(isObject(account) ? account : {}),
+    },
     setUser: (user) => {
       window.localStorage.setItem("user", JSON.stringify(user));
       setUser(user);
@@ -58,6 +64,26 @@ export default function SpecializedApp({ Component, pageProps }) {
   useEffect(() => {
     if (isNone(user)) {
       router.push("/");
+    } else {
+      const retrieveAccount = async () => {
+        const response = await mainAPI.getAccount();
+
+        if (response.status === 401) {
+          setUser(null);
+          return;
+        }
+
+        if (response.status !== 200) {
+          // Show error if not success
+          return;
+        }
+
+        const data = await response.json();
+
+        setAccount(data);
+      };
+
+      retrieveAccount();
     }
   }, [user]);
 

--- a/pages/_app/index.js
+++ b/pages/_app/index.js
@@ -1,4 +1,5 @@
 import { useState, useReducer, useEffect } from "react";
+import { useRouter } from "next/router";
 
 import { Sky } from "@components/index";
 import { AppContext } from "@contexts/index";
@@ -13,6 +14,7 @@ import "./index.css";
 export default function SpecializedApp({ Component, pageProps }) {
   const [modalDataList, modalDispatch] = useReducer(modalUpdateHandler, []);
   const [user, setUser] = useState(null);
+  const router = useRouter();
 
   const modal = {
     add: (component) => {
@@ -52,6 +54,12 @@ export default function SpecializedApp({ Component, pageProps }) {
       setUser(null);
     }
   }, []);
+
+  useEffect(() => {
+    if (isNone(user)) {
+      router.push("/");
+    }
+  }, [user]);
 
   return (
     <AppContext.Provider value={appContextValue}>

--- a/scenes/Dashboard/components/Home/index.js
+++ b/scenes/Dashboard/components/Home/index.js
@@ -89,24 +89,32 @@ export default function Home() {
         </Text>
         <Gap gap={24} />
         <Box direction="row" crossAxis="center" width="60%">
-          <Field
-            value={queries.fields[QUERY_TYPES.NIK].value}
-            placeholder={QUERY_TYPES.NIK}
-            onChange={(value) => setQuery(QUERY_TYPES.NIK, value)}
-          />
+          <Box maxWidth="16rem">
+            <Field
+              value={queries.fields[QUERY_TYPES.NIK].value}
+              placeholder={QUERY_TYPES.NIK}
+              onChange={(value) => setQuery(QUERY_TYPES.NIK, value)}
+            />
+          </Box>
           <Gap gap={16} />
-          <Field
-            value={queries.fields[QUERY_TYPES.FULL_NAME].value}
-            placeholder={QUERY_TYPES.FULL_NAME}
-            onChange={(value) => setQuery(QUERY_TYPES.FULL_NAME, value)}
-          />
+          <Box maxWidth="14rem">
+            <Field
+              value={queries.fields[QUERY_TYPES.FULL_NAME].value}
+              placeholder={QUERY_TYPES.FULL_NAME}
+              onChange={(value) => setQuery(QUERY_TYPES.FULL_NAME, value)}
+            />
+          </Box>
           <Gap gap={16} />
-          <Field
-            type="date"
-            value={queries.fields[QUERY_TYPES.CHECK_UP_DATETIME].value}
-            placeholder={QUERY_TYPES.CHECK_UP_DATETIME}
-            onChange={(value) => setQuery(QUERY_TYPES.CHECK_UP_DATETIME, value)}
-          />
+          <Box minWidth="14rem">
+            <Field
+              type="date"
+              value={queries.fields[QUERY_TYPES.CHECK_UP_DATETIME].value}
+              placeholder={QUERY_TYPES.CHECK_UP_DATETIME}
+              onChange={(value) =>
+                setQuery(QUERY_TYPES.CHECK_UP_DATETIME, value)
+              }
+            />
+          </Box>
         </Box>
       </Box>
       <Box padding={`4rem ${48 / 16}rem 0`} direction="column" width="100%">
@@ -136,6 +144,7 @@ export default function Home() {
           direction="row"
           mainAxis="center"
           crossAxis="center"
+          margin="1rem 0"
           grow={1}
           shrink={0}
         >
@@ -153,7 +162,7 @@ export default function Home() {
           </Click>
           <Box padding="0 1.5rem">
             <Text color={COLORS.BLUE} size={SIZES.REGULAR}>
-              Page {pageNumber}
+              Halaman {pageNumber}
             </Text>
           </Box>
           <Click

--- a/scenes/Dashboard/index.js
+++ b/scenes/Dashboard/index.js
@@ -24,8 +24,12 @@ export default function Dashboard() {
   const router = useRouter();
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
+
+  const tabIndex = TABS.findIndex(
+    ({ endpoint }) => endpoint === router.pathname
+  );
   const [selectedTabIndex, setSelectedTabIndex] = useState(
-    TABS.findIndex(({ endpoint }) => endpoint === router.pathname)
+    tabIndex < 0 ? 0 : tabIndex
   );
 
   const tabOnClick = (index, extraFunc) => {

--- a/scenes/Dashboard/index.js
+++ b/scenes/Dashboard/index.js
@@ -195,7 +195,7 @@ export default function Dashboard() {
               size={SIZES.NORMAL}
               weight={FONT_WEIGHTS.BOLD}
             >
-              {user && user.name && ""}
+              {user && user.name}
             </Text>
           </Box>
         </Box>

--- a/scenes/Home/constants.js
+++ b/scenes/Home/constants.js
@@ -1,7 +1,7 @@
 export const GREETING_WORD = "Selamat datang";
-export const AFTER_GREETING_WORD = "di Cardicare EHR";
+export const AFTER_GREETING_WORD = "di CardiCare EHR";
 export const WEBSITE_DESCRIPTION =
-  "Aplikasi berbasis web untuk mengelola dan melihat data pasien instansi Anda. Ditujukan sebagai pendamping aplikasi Cardicare.";
+  "Aplikasi berbasis web untuk mengelola dan melihat data pasien instansi Anda. Ditujukan sebagai pendamping aplikasi CardiCare.";
 
 export const TOPBAR_TITLES = {
   LOGIN: "Masuk",


### PR DESCRIPTION
# Background
Currently, we split the profile API based on its role, and as we developed dashboard we found a trouble to show the profile in the dashboard because of these split APIs. To make it simple we generalize all the API into one API only that can be used by any roles.

## Changes
- [x] Implement API hit
- [x] Call API hit from Dashboard
- [x] Create mechanism to logout automatically if gives 401 status when try to hit account API